### PR TITLE
Experimental support for setting light waveforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This module provides input and output nodes for communicating with Lifx lights, 
 * Trigger events for light changes
 * Self syncing, uses background polling to detect external changes to light
 * Displays current state for light in Node-Red ui
+* ability to set waveform
 
 
 ### Examples
@@ -54,6 +55,20 @@ More advanced way to control the light is to send an object payload with one or 
 | `cr`, `mired` or `mirek` | Set Mired color temperature (153 - 500) |
 | `kelvin` | Set kelvin color temperature (2200-6500) |
 | `duration` | Transition time (ms) |
+
+*setting waveform*
+Waveform is a way to create effect in lifx bulbs, like the breath effect in the Lifx App. Setting a wave form will be at the following JSON form.
+
+```json
+{
+  "isTransient": true,
+  "color": {"hue": 0, "saturation": 65535, "brightness": 65535, "kelvin": 3500},
+  "period": 800,
+  "cycles": 3,
+  "skewRatio": 0,
+  "waveform": "SINE"  // one of  SAW, SINE, HALF_SINE, TRIANGLE, PULSE
+}
+```
 
 **Notice:** to get the same behavioras the Lifx app when modifying the color temperature you will need to manually set the saturation to zero. This is because the Lifx light can adjust temperature and color independent of each other and I didn't want to limit the choices for the user.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module provides input and output nodes for communicating with Lifx lights, 
 * Trigger events for light changes
 * Self syncing, uses background polling to detect external changes to light
 * Displays current state for light in Node-Red ui
-* ability to set waveform
+* ability to set waveform (EXPERIMENTAL)
 
 
 ### Examples
@@ -66,7 +66,7 @@ Waveform is a way to create effect in lifx bulbs, like the breath effect in the 
   "period": 800,
   "cycles": 3,
   "skewRatio": 0,
-  "waveform": "SINE"  // one of  SAW, SINE, HALF_SINE, TRIANGLE, PULSE
+  "waveform": "SINE"  // one of SAW, SINE, HALF_SINE, TRIANGLE, PULSE
 }
 ```
 

--- a/lib/lifx-server.js
+++ b/lib/lifx-server.js
@@ -41,6 +41,14 @@ LightHandler.prototype.setLightState = function setState(data) {
   return this.lightServer.setLightState(this.id, data);
 };
 
+/**
+ * Set waveform of light
+ * @param  {object}  data New light data
+ * @return {boolean}      False if there is no such light or it's not discovered yet
+ */
+LightHandler.prototype.setLightWaveForm = function setState(data) {
+  return this.lightServer.setLightWaveForm(this.id, data);
+};
 
 /**
  * Send data to light
@@ -325,6 +333,37 @@ LightServer.prototype.getLights = function getLights() {
   }, []);
 
   return retVal;
+}
+
+/**
+ * Set light state wave form
+ * 
+ * example {
+ *   isTransient: true,
+ *   color: {hue: 0, saturation: 65535, brightness: 65535, kelvin: 3500},
+ *   period: 800,
+ *  cycles: 3,
+ *  skewRatio: 0,
+ *  waveform:  SAW, SINE, HALF_SINE, TRIANGLE, PULSE
+ * }
+ * @param  {string} lightID ID/Label for the light
+ * @param  {object} value   New values for the light wave form
+ * @return {boolean}        False if no such light exists
+ */
+LightServer.prototype.setLightWaveForm = function setLightWaveForm(lightID, value) {
+
+  if (!this.lights.hasOwnProperty(lightID))
+    return false;
+
+  value.waveform = nodeLifx.constants.LIGHT_WAVEFORMS.indexOf(value.waveform)
+
+  var packetObj = nodeLifx.packet.create('setWaveform', value, this.lifxClient.source);
+
+  packetObj.target = lightID
+
+  this.lifxClient.send(packetObj, () => {})
+  
+  return true;
 }
 
 

--- a/lib/lifx-server.js
+++ b/lib/lifx-server.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _            = require('lodash');
-var LifxClient   = require('lifx-lan-client').Client;
+var lifxLan      = require('lifx-lan-client');
 
 var inherits     = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
@@ -122,7 +122,7 @@ function LightServer(config) {
     this.lifxConfig.lights = this.config.lights.split(/ *, */g);
 
   // Create new API
-  this.lifxClient = new LifxClient();
+  this.lifxClient = new lifxLan.Client();
 
   // New lifx detected
   this.lifxClient.on('light-new', (lifxLight) => {
@@ -355,11 +355,10 @@ LightServer.prototype.setLightWaveForm = function setLightWaveForm(lightID, valu
   if (!this.lights.hasOwnProperty(lightID))
     return false;
 
-  value.waveform = nodeLifx.constants.LIGHT_WAVEFORMS.indexOf(value.waveform)
+  value.waveform = lifxLan.constants.LIGHT_WAVEFORMS.indexOf(value.waveform)
 
-  var packetObj = nodeLifx.packet.create('setWaveform', value, this.lifxClient.source);
-
-  packetObj.target = lightID
+  var packetObj = lifxLan.packet.create('setWaveform', value, this.lifxClient.source);
+  packetObj.target = lightID;
 
   this.lifxClient.send(packetObj, () => {})
 

--- a/lib/lifx-server.js
+++ b/lib/lifx-server.js
@@ -1,12 +1,12 @@
 "use strict";
 
+var _            = require('lodash');
 var LifxClient   = require('lifx-lan-client').Client;
-//var nodeLifx   = require('./node-lifx-emulator.js')
-var _          = require('lodash');
-var LightItem  = require('./lifx-light.js');
 
-var inherits      = require('util').inherits;
-var EventEmitter  = require('events').EventEmitter;
+var inherits     = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
+
+var LightItem    = require('./lifx-light.js');
 
 
 /**
@@ -337,7 +337,7 @@ LightServer.prototype.getLights = function getLights() {
 
 /**
  * Set light state wave form
- * 
+ *
  * example {
  *   isTransient: true,
  *   color: {hue: 0, saturation: 65535, brightness: 65535, kelvin: 3500},
@@ -362,7 +362,7 @@ LightServer.prototype.setLightWaveForm = function setLightWaveForm(lightID, valu
   packetObj.target = lightID
 
   this.lifxClient.send(packetObj, () => {})
-  
+
   return true;
 }
 

--- a/red/lifx-node.js
+++ b/red/lifx-node.js
@@ -88,7 +88,12 @@ module.exports = function(RED, isOutput) {
     node.on('input', (msg) => {
       if (!node.isOutput && node.lightHandler) {
         try {
-          node.lightHandler.setLightState(msg.payload);
+          if (msg.payload.waveform) {
+            node.lightHandler.setLightWaveForm(msg.payload);
+          } else {
+            node.lightHandler.setLightState(msg.payload);
+          }
+          
         }
         catch (e) {
           node.error(e.message, e.stack);


### PR DESCRIPTION
This merges https://github.com/jdomeij/node-red-contrib-node-lifx/pull/8 and adapts it to work with the changes on this fork.

The feature is marked experimental as:
- the current implementation uses raw packets as there's no
  official support for the command on lifx-lan-client
- there's no validation for the input properties
- brightness and hue values use 0-65535 range instead of
  0-100 / 0-360
- output node info tab documentation is missing

Example payload to test (note the raw saturation and brightness ranges):
```js
{
  "isTransient": true,
  "color": {"hue": 0, "saturation": 65535, "brightness": 65535, "kelvin": 3500},
  "period": 800,
  "cycles": 3,
  "skewRatio": 0,
  "waveform": "SINE"  // one of SAW, SINE, HALF_SINE, TRIANGLE, PULSE
}

```

Closes #4.